### PR TITLE
Housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "llq"
 version = "0.1.1"
 authors = ["Micah Johnston <micah@glowcoil.com>"]
-edition = "2018"
+edition = "2021"
 description = "Wait-free SPSC linked-list queue with individually reusable nodes"
 repository = "https://github.com/glowcoil/llq"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A wait-free single-producer single-consumer linked-list queue with individually 
 
 Queue operations do not block or allocate memory. Individual nodes are allocated and managed separately, and can be reused on multiple queues.
 
-# Examples
+## Examples
 
 Using a queue to send values between threads:
 
@@ -45,10 +45,6 @@ let node = consumer2.pop().unwrap();
 
 assert_eq!(*node, 3);
 ```
-
-[`Producer::push()`]: crate::Producer::push
-[`Consumer::pop()`]: crate::Consumer::pop
-[`Node`]: crate::Node
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ impl<T> Queue<T> {
     pub fn split(self) -> (Producer<T>, Consumer<T>) {
         let queue = Arc::new(self);
 
-        let producer = Producer { queue: queue.clone(), tail: queue.head.get() };
+        let producer = Producer { queue: Arc::clone(&queue), tail: queue.head.get() };
         let consumer = Consumer { queue };
 
         (producer, consumer)
@@ -318,7 +318,7 @@ mod tests {
         let counter = Arc::new(Cell::new(0));
 
         for _ in 0..10000 {
-            producer.push(Node::new(S(counter.clone())));
+            producer.push(Node::new(S(Arc::clone(&counter))));
         }
 
         while let Some(_) = consumer.pop() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,12 @@
 //! [`Node`]: crate::Node
 
 #![no_std]
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![warn(unreachable_pub)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::clone_on_ref_ptr)]
+#![warn(rustdoc::broken_intra_doc_links)]
 
 extern crate alloc;
 
@@ -267,9 +273,8 @@ mod tests {
                 if let Some(node) = consumer.pop() {
                     if *node {
                         break;
-                    } else {
-                        counter += 1;
                     }
+                    counter += 1;
                 }
             }
 
@@ -297,7 +302,7 @@ mod tests {
         assert_eq!(counter, 10000);
 
         let mut counter = 0;
-        while let Some(_) = consumer2.pop() {
+        while consumer2.pop().is_some() {
             counter += 1;
         }
         assert_eq!(counter, 10000);
@@ -321,7 +326,7 @@ mod tests {
             producer.push(Node::new(S(Arc::clone(&counter))));
         }
 
-        while let Some(_) = consumer.pop() {}
+        while consumer.pop().is_some() {}
 
         assert_eq!(counter.get(), 10000);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,12 @@ impl<T> Queue<T> {
     }
 }
 
+impl<T> Default for Queue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> Drop for Queue<T> {
     fn drop(&mut self) {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ struct NodeInner<T> {
 
 impl<T> Node<T> {
     /// Allocates a new node containing the given value.
+    #[must_use]
     pub fn new(data: T) -> Node<T> {
         Node {
             inner: unsafe {
@@ -94,6 +95,7 @@ impl<T> Node<T> {
     }
 
     /// Deallocates a `Node` and returns the inner value.
+    #[must_use]
     pub fn into_inner(this: Node<T>) -> T {
         unsafe {
             let data = ptr::read(this.inner.as_ref().data.as_ptr());
@@ -137,6 +139,7 @@ unsafe impl<T: Send> Send for Queue<T> {}
 
 impl<T> Queue<T> {
     /// Creates a new queue.
+    #[must_use]
     pub fn new() -> Queue<T> {
         let node = Box::into_raw(Box::new(NodeInner {
             next: AtomicPtr::new(ptr::null_mut()),
@@ -147,6 +150,7 @@ impl<T> Queue<T> {
     }
 
     /// Splits a queue into its producer and consumer halves.
+    #[must_use]
     pub fn split(self) -> (Producer<T>, Consumer<T>) {
         let queue = Arc::new(self);
 


### PR DESCRIPTION
Some minor, non-functional updates and additional checks. Most of the changes were suggested by running `cargo clippy --all-targets` with the extended warning config.

Upgrading the Rust edition and adding `#[must_use]` attributes might require to bump the version to 0.2?